### PR TITLE
feat: added configuration support for S3_SHARDED storage type

### DIFF
--- a/charts/testops/CHANGELOG.md
+++ b/charts/testops/CHANGELOG.md
@@ -10,6 +10,10 @@ Entries are ordered by priority:
 4. `[BUGFIX]` Fixes for defects
 5. `[DOCS]` Update of the documentation in `values.yaml`
 
+## 5.27.0
+
+- [FEATURE] Added configuration support for `S3_SHARDED` storage type, allowing users to configure multiple S3 storages and map them to specific projects.
+
 ## 5.26.2
 
 - [BUGFIX] Fixed scientific notation in the application's thread pool configuration.

--- a/charts/testops/Chart.yaml
+++ b/charts/testops/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: testops
-version: 5.26.2
+version: 5.27.0
 appVersion: 26.1.1
 kubeVersion: '>= 1.20.0-0'
 

--- a/charts/testops/Chart.yaml
+++ b/charts/testops/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: testops
 version: 5.27.0
-appVersion: 26.1.1
+appVersion: 26.2.1
 kubeVersion: '>= 1.20.0-0'
 
 dependencies:

--- a/charts/testops/templates/_helpers.tpl
+++ b/charts/testops/templates/_helpers.tpl
@@ -559,6 +559,7 @@
 
 
 {{- define "renderS3Envs" }}
+{{- $s3Prefix := ternary "S3SHARDED" "S3" (eq .Values.storage.type "S3_SHARDED") }}
   - name: ALLURE_BLOBSTORAGE_TYPE
     value: {{ .Values.storage.type }}
   - name: ALLURE_BLOBSTORAGE_MAXCONCURRENCY
@@ -577,45 +578,45 @@
   - name: ALLURE_BLOBSTORAGE_COPYSUPPORTED
     value: {{ .Values.storage.s3.advancedS3SDK.copySupported | quote}}
 {{- end }}
-  - name: ALLURE_BLOBSTORAGE_S3_ENDPOINT
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_ENDPOINT
 {{- if .Values.minio.enabled }}
     value: http://{{ template "testops.minio.fullname" . }}:{{ .Values.minio.service.ports.api }}
-  - name: ALLURE_BLOBSTORAGE_S3_PATHSTYLEACCESS
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_PATHSTYLEACCESS
     value: "true"
 {{- else }}
     value: {{ .Values.storage.s3.endpoint }}
-  - name: ALLURE_BLOBSTORAGE_S3_PATHSTYLEACCESS
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_PATHSTYLEACCESS
     value: "{{ .Values.storage.s3.pathstyle }}"
 {{- end }}
-  - name: ALLURE_BLOBSTORAGE_S3_BUCKET
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_BUCKET
 {{- if .Values.minio.enabled }}
     value: {{ .Values.minio.defaultBuckets }}
 {{- else }}
     value: {{ .Values.storage.s3.bucket }}
 {{- end }}
-  - name: ALLURE_BLOBSTORAGE_S3_REGION
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_REGION
 {{- if .Values.minio.enabled }}
     value: {{ .Values.minio.defaultRegion }}
 {{- else }}
     value: {{ .Values.storage.s3.region}}
 {{- end }}
 {{- if not .Values.storage.awsSTS.enabled }}
-  - name: ALLURE_BLOBSTORAGE_S3_ACCESSKEY
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_ACCESSKEY
     valueFrom:
       secretKeyRef:
         name: {{ template "testops.secret.name" . }}
         key: "s3AccessKey"
-  - name: ALLURE_BLOBSTORAGE_S3_SECRETKEY
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_SECRETKEY
     valueFrom:
       secretKeyRef:
         name: {{ template "testops.secret.name" . }}
         key: "s3SecretKey"
 {{- end }}
 {{- if .Values.storage.s3.serverSideEncryption.enabled }}
-  - name: ALLURE_BLOB_STORAGE_S3_SERVER_SIDE_ENCRYPTION
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_SERVERSIDEENCRYPTION
     value: {{ .Values.storage.s3.serverSideEncryption.type | quote }}
 {{- if .Values.storage.s3.serverSideEncryption.keyId }}
-  - name: ALLURE_BLOB_STORAGE_S3_KMS_KEY_ID
+  - name: ALLURE_BLOBSTORAGE_{{ $s3Prefix }}_KMSKEYID
     value: {{ .Values.storage.s3.serverSideEncryption.keyId | quote }}
 {{- end }}
 {{- end }}

--- a/charts/testops/templates/_helpers.tpl
+++ b/charts/testops/templates/_helpers.tpl
@@ -644,6 +644,10 @@
   - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_SECRETKEY
     value: {{ $storage.secretKey | quote }}
 {{- end }}
+{{- if $storage.pathstyle }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_PATHSTYLEACCESS
+    value: {{ $storage.pathstyle | quote }}
+{{- end }}
 {{- if and $storage.serverSideEncryption $storage.serverSideEncryption.enabled }}
   - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_SERVERSIDEENCRYPTION
     value: {{ $storage.serverSideEncryption.type | quote }}

--- a/charts/testops/templates/_helpers.tpl
+++ b/charts/testops/templates/_helpers.tpl
@@ -619,6 +619,51 @@
     value: {{ .Values.storage.s3.serverSideEncryption.keyId | quote }}
 {{- end }}
 {{- end }}
+
+{{- if eq .Values.storage.type "S3_SHARDED" }}
+{{- range $index, $storage := .Values.storage.s3.additionalStorages }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_NAME
+    value: {{ $storage.name | quote }}
+{{- if $storage.endpoint }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_ENDPOINT
+    value: {{ $storage.endpoint | quote }}
+{{- end }}
+{{- if $storage.bucket }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_BUCKET
+    value: {{ $storage.bucket | quote }}
+{{- end }}
+{{- if $storage.region }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_REGION
+    value: {{ $storage.region | quote }}
+{{- end }}
+{{- if $storage.accessKey }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_ACCESSKEY
+    value: {{ $storage.accessKey | quote }}
+{{- end }}
+{{- if $storage.secretKey }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_SECRETKEY
+    value: {{ $storage.secretKey | quote }}
+{{- end }}
+{{- if and $storage.serverSideEncryption $storage.serverSideEncryption.enabled }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_SERVERSIDEENCRYPTION
+    value: {{ $storage.serverSideEncryption.type | quote }}
+{{- if $storage.serverSideEncryption.keyId }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_STORAGES_{{ $index }}_KMSKEYID
+    value: {{ $storage.serverSideEncryption.keyId | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- range $projectId, $config := .Values.storage.s3.projects }}
+{{- if $config.storage }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_PROJECTS_{{ $projectId }}_STORAGE
+    value: {{ $config.storage | quote }}
+{{- end }}
+{{- if $config.bucket }}
+  - name: ALLURE_BLOBSTORAGE_S3SHARDED_PROJECTS_{{ $projectId }}_BUCKET
+    value: {{ $config.bucket | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "renderFSEnvs" }}

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -112,7 +112,7 @@ timeZone: "Europe/London"
 # Make sure SMTP parameters are set to send the invite.
 # SMTP server settings are mandatory for the creation of first user.
 ############################################################################################################
-email: you@company.com
+email: first.admin@email.company.com
 
 ############################################################################################################
 # cryptoPass parameter is used to encrypt sensitive data (passwords, API tokens in the database)

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -402,7 +402,7 @@ storage:
     # Some providers have path style access like s3.provider.com/bucket-name others have domain style
     # Like bucket-name.s3.provider.com. Choose your provider's
     ############################################################################################################
-    # AWS S3 supports both pathstyle: false/true, other solutions most likely support false only
+    # AWS S3 supports both pathstyle: false/true, other solutions (minio etc) most likely support TRUE only
     ############################################################################################################
     pathstyle: false
     bucket: testops-testops
@@ -427,6 +427,7 @@ storage:
       # Ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#aws-managed-customer-managed-keys
       keyId:
     ## @param storage.s3.additionalStorages defines an array of additional S3 storages for S3_SHARDED mode.
+    ## Storage represents an isolated solution with its own endpoint, bucket, region, accessKey, secretKey, and serverSideEncryption settings.
     ## Each storage requires a unique 'name' and can override default S3 parameters like endpoint, bucket, region, accessKey, secretKey, and serverSideEncryption.
     ## e.g:
     ## additionalStorages:
@@ -434,6 +435,9 @@ storage:
     ##     endpoint: "https://s3.eu-central-1.amazonaws.com"
     ##     bucket: "allure-eu-bucket"
     ##     region: "eu-central-1"
+    ##     accessKey: "EU_ACCESS_KEY"
+    ##     secretKey: "EU_SECRET_KEY"
+    ##     pathstyle: false
     ##     serverSideEncryption:
     ##       enabled: true
     ##       type: "AWS_KMS"
@@ -442,13 +446,20 @@ storage:
     additionalStorages: []
     ## @param storage.s3.projects defines a map of project-specific S3 configurations for S3_SHARDED mode.
     ## The key is the project ID. You can specify a custom 'bucket' and/or a 'storage' name (referencing an entry from additionalStorages).
+    ## If a certain project only uses separate bucket but the same S3 solution, specify only bucket name, and do not specify storage name (see 45).
     ## If a property is not set, the default S3 configuration will be used.
     ## e.g:
     ## projects:
-    ##   12:
+    ##   
+    ##   12: // project 12 uses default bucket defined for "eu-storage"
     ##     storage: "eu-storage"
-    ##   45:
+    ##   
+    ##   45: //project 45 uses default S3 solution but dedicated bucket "custom-us-bucket"
     ##     bucket: "custom-us-bucket"
+    ##  
+    ##   90: project 90 uses storage "eu-storage" but its own (not default) bucket – "custom-eu-bucket"
+    ##     storage: "eu-storage"
+    ##     bucket: "custom-eu-bucket"
     ##
     projects: []
   csi:

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -18,7 +18,7 @@
 # for version upgrades, select the desired version of the application and the most recent chart
 # minimal version of Testops supported by this chart is 26.1.1
 ############################################################################################################
-version: 26.2.1
+version: 26.1.1
 
 ############################################################################################################
 # Deploy related

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -449,13 +449,13 @@ storage:
     ## If a property is not set, the default S3 configuration will be used.
     ## e.g:
     ## projects:
-    ##   
+    ##
     ##   12: // project 12 uses default bucket defined for "eu-storage"
     ##     storage: "eu-storage"
-    ##   
+    ##
     ##   45: //project 45 uses default S3 solution but dedicated bucket "custom-us-bucket"
     ##     bucket: "custom-us-bucket"
-    ##  
+    ##
     ##   90: project 90 uses storage "eu-storage" but its own (not default) bucket – "custom-eu-bucket"
     ##     storage: "eu-storage"
     ##     bucket: "custom-eu-bucket"

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -402,7 +402,7 @@ storage:
     # Some providers have path style access like s3.provider.com/bucket-name others have domain style
     # Like bucket-name.s3.provider.com. Choose your provider's
     ############################################################################################################
-    # AWS S3 supports both pathstyle: false/true, other solutions (minio etc) most likely support TRUE only
+    # AWS S3 supports both pathstyle: false/true, other solutions (minio, ceph etc) most likely support TRUE only
     ############################################################################################################
     pathstyle: false
     bucket: testops-testops

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -366,7 +366,9 @@ smtp:
 # 2) S3_ASYNC - recommended for AWS S3, this option supports parameters described in .Values.storage.s3.advancedS3SDK
 # S3_ASYNC allows usage of optimised commands towards S3 solution (e.g. delete objects). Consult your solution
 # documentation before using this option
-# 3) CSI
+# 3) S3_SHARDED - allows configuring multiple S3 storages
+# and mapping them to specific projects via .Values.storage.s3.additionalStorages and .Values.storage.s3.projects
+# 4) CSI
 # For CSI refer to https://kubernetes-csi.github.io/docs/drivers.html
 # S3 is preferable. The best option is using SaaS S3 AWS or other S3 comparable services.
 # It's highly recommended disabling versioning for S3 from the very start
@@ -377,6 +379,7 @@ storage:
   # Options are:
   # - S3
   # - S3_ASYNC
+  # - S3_SHARDED
   # - CSI
   type: "S3"
   s3:
@@ -423,6 +426,31 @@ storage:
       # The ARN format is: arn:aws:kms:<region>:<account-id>:key/<key-id>
       # Ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#aws-managed-customer-managed-keys
       keyId:
+    ## @param storage.s3.additionalStorages defines an array of additional S3 storages for S3_SHARDED mode.
+    ## Each storage requires a unique 'name' and can override default S3 parameters like endpoint, bucket, region, accessKey, secretKey, and serverSideEncryption.
+    ## e.g:
+    ## additionalStorages:
+    ##   - name: "eu-storage"
+    ##     endpoint: "https://s3.eu-central-1.amazonaws.com"
+    ##     bucket: "allure-eu-bucket"
+    ##     region: "eu-central-1"
+    ##     serverSideEncryption:
+    ##       enabled: true
+    ##       type: "AWS_KMS"
+    ##       keyId: "arn:aws:kms:eu-central-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    ##
+    additionalStorages: []
+    ## @param storage.s3.projects defines a map of project-specific S3 configurations for S3_SHARDED mode.
+    ## The key is the project ID. You can specify a custom 'bucket' and/or a 'storage' name (referencing an entry from additionalStorages).
+    ## If a property is not set, the default S3 configuration will be used.
+    ## e.g:
+    ## projects:
+    ##   12:
+    ##     storage: "eu-storage"
+    ##   45:
+    ##     bucket: "custom-us-bucket"
+    ##
+    projects: []
   csi:
     storageClass: ""
     existingVolumeName: ""

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -18,7 +18,7 @@
 # for version upgrades, select the desired version of the application and the most recent chart
 # minimal version of Testops supported by this chart is 26.1.1
 ############################################################################################################
-version: 26.1.1
+version: 26.2.1
 
 ############################################################################################################
 # Deploy related

--- a/charts/testops/values.yaml
+++ b/charts/testops/values.yaml
@@ -428,7 +428,7 @@ storage:
       keyId:
     ## @param storage.s3.additionalStorages defines an array of additional S3 storages for S3_SHARDED mode.
     ## Storage represents an isolated solution with its own endpoint, bucket, region, accessKey, secretKey, and serverSideEncryption settings.
-    ## Each storage requires a unique 'name' and can override default S3 parameters like endpoint, bucket, region, accessKey, secretKey, and serverSideEncryption.
+    ## Each storage requires a unique 'name' and can override default S3 parameters like endpoint, bucket, region, accessKey, secretKey, pathstyleand serverSideEncryption.
     ## e.g:
     ## additionalStorages:
     ##   - name: "eu-storage"
@@ -446,7 +446,6 @@ storage:
     additionalStorages: []
     ## @param storage.s3.projects defines a map of project-specific S3 configurations for S3_SHARDED mode.
     ## The key is the project ID. You can specify a custom 'bucket' and/or a 'storage' name (referencing an entry from additionalStorages).
-    ## If a certain project only uses separate bucket but the same S3 solution, specify only bucket name, and do not specify storage name (see 45).
     ## If a property is not set, the default S3 configuration will be used.
     ## e.g:
     ## projects:


### PR DESCRIPTION
closes qameta/testops-feedback#111

Added configuration support for `S3_SHARDED` storage type, allowing users to configure multiple S3 storages and map them to specific projects.